### PR TITLE
fix: single ']' character output when no data matches the query

### DIFF
--- a/cmd/list/orgs/orgs.go
+++ b/cmd/list/orgs/orgs.go
@@ -24,7 +24,7 @@ var OrgsCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		
+
 		orgsDir := args[0]
 
 		orgs, err := functions.FindManagedOrgs(orgsDir)
@@ -42,7 +42,11 @@ var OrgsCmd = &cobra.Command{
 				orgOut = fmt.Sprintf("['%s'", org)
 			}
 		}
-		orgOut = fmt.Sprintf("%s]", orgOut)
+		if orgOut != "" {
+			orgOut = fmt.Sprintf("%s]", orgOut)
+		} else {
+			orgOut = "[]"
+		}
 
 		fmt.Println(orgOut)
 

--- a/cmd/list/orgs/orgs.go
+++ b/cmd/list/orgs/orgs.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"gh_foundations/internal/pkg/functions"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -33,19 +34,10 @@ var OrgsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		var orgOut string
-		orgOut = ""
-		for _, org := range orgs {
-			if orgOut != "" {
-				orgOut = fmt.Sprintf("%s, '%s'", orgOut, org)
-			} else {
-				orgOut = fmt.Sprintf("['%s'", org)
-			}
-		}
-		if orgOut != "" {
-			orgOut = fmt.Sprintf("%s]", orgOut)
-		} else {
-			orgOut = "[]"
+		var orgOut string = "[]"
+
+		if len(orgs) > 0 {
+			orgOut = fmt.Sprintf("['%s']", strings.Join(orgs, "', '"))
 		}
 
 		fmt.Println(orgOut)

--- a/cmd/list/repos/repos.go
+++ b/cmd/list/repos/repos.go
@@ -10,6 +10,7 @@ import (
 	"gh_foundations/internal/pkg/types/status"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -37,23 +38,17 @@ var ReposCmd = &cobra.Command{
 			log.Fatalf("Error in findManagedRepos: %s", err)
 		}
 
+		repoList := flattenRepos(orgSet)
+
 		if ghas {
 			orgSet = orgSet.WithGHASEnabled()
-			log.Printf("Found %d repositories with GHAS enabled\n", len(flattenRepos(orgSet)))
+			repoList = flattenRepos(orgSet)
+			log.Printf("Found %d repositories with GHAS enabled\n", len(repoList))
 		}
-		var repos string
-		repos = ""
-		for _, repo := range flattenRepos(orgSet) {
-			if repos != "" {
-				repos = fmt.Sprintf("%s, '%s'", repos, repo)
-			} else {
-				repos = fmt.Sprintf("['%s'", repo)
-			}
-		}
-		if repos != "" {
-			repos = fmt.Sprintf("%s]", repos)
-		} else {
-			repos = "[]"
+
+		repos := "[]"
+		if len(repoList) > 0 {
+			repos = fmt.Sprintf("['%s']", strings.Join(repoList, "', '"))
 		}
 
 		fmt.Println(repos)

--- a/cmd/list/repos/repos.go
+++ b/cmd/list/repos/repos.go
@@ -36,7 +36,7 @@ var ReposCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error in findManagedRepos: %s", err)
 		}
-		
+
 		if ghas {
 			orgSet = orgSet.WithGHASEnabled()
 			log.Printf("Found %d repositories with GHAS enabled\n", len(flattenRepos(orgSet)))
@@ -50,7 +50,11 @@ var ReposCmd = &cobra.Command{
 				repos = fmt.Sprintf("['%s'", repo)
 			}
 		}
-		repos = fmt.Sprintf("%s]", repos)
+		if repos != "" {
+			repos = fmt.Sprintf("%s]", repos)
+		} else {
+			repos = "[]"
+		}
 
 		fmt.Println(repos)
 	},


### PR DESCRIPTION
### ISSUE

[#8] - [Bug] single ']' character output when no data matches the query

When no `repositories` or `organizations` are found using one of the `list` commands, a single `]` character is output. This break JSON parsing libraries that use this output.

--- 