### PR TITLE
fix: typo in assessment results

### DIFF
--- a/cmd/check/check.go
+++ b/cmd/check/check.go
@@ -40,13 +40,13 @@ var CheckCmd = &cobra.Command{
 		gs := github.NewGithubService(authToken)
 		org, err := gs.GetOrganization(slug)
 		if err == nil {
-			reports = append(reports, org.Check([]types.CheckType{types.GoCGaurdrails}))
+			reports = append(reports, org.Check([]types.CheckType{types.GoCGuardrails}))
 		}
 
 		repos, err := gs.GetRepositories(slug, nil)
 		if err == nil {
 			for _, r := range repos {
-				reports = append(reports, r.Check([]types.CheckType{types.GoCGaurdrails}))
+				reports = append(reports, r.Check([]types.CheckType{types.GoCGuardrails}))
 			}
 		}
 

--- a/internal/pkg/types/checks.go
+++ b/internal/pkg/types/checks.go
@@ -39,7 +39,7 @@ type CheckError struct {
 type CheckType string
 
 const (
-	GoCGaurdrails = "GoCGaurdrails"
+	GoCGuardrails = "GoCGuardrails"
 )
 
 type CheckReport struct {

--- a/internal/pkg/types/github/organization.go
+++ b/internal/pkg/types/github/organization.go
@@ -22,7 +22,7 @@ func (o *Organization) Check(checkTypes []types.CheckType) types.CheckReport {
 	}
 	for _, t := range checkTypes {
 		switch t {
-		case types.GoCGaurdrails:
+		case types.GoCGuardrails:
 			r, err := o.GoCGaurdrailsCompliant()
 			if err != nil {
 				report.Errors = append(report.Errors, *err)
@@ -163,7 +163,7 @@ func (o *Organization) GoCGaurdrailsCompliant() (types.CheckResult, *types.Check
 	if allErrors != nil {
 		return types.Failed, &types.CheckError{
 			Err:        allErrors,
-			Check:      types.GoCGaurdrails,
+			Check:      types.GoCGuardrails,
 			Violations: violations,
 		}
 	}

--- a/internal/pkg/types/github/repository.go
+++ b/internal/pkg/types/github/repository.go
@@ -24,7 +24,7 @@ func (r *Repository) Check(checkTypes []types.CheckType) types.CheckReport {
 	}
 	for _, t := range checkTypes {
 		switch t {
-		case types.GoCGaurdrails:
+		case types.GoCGuardrails:
 			r, err := r.GoCGaurdrailsCompliant()
 			if err != nil {
 				report.Errors = append(report.Errors, *err)
@@ -109,7 +109,7 @@ func (r *Repository) GoCGaurdrailsCompliant() (types.CheckResult, *types.CheckEr
 	if allErrors != nil {
 		return types.Failed, &types.CheckError{
 			Err:        allErrors,
-			Check:      types.GoCGaurdrails,
+			Check:      types.GoCGuardrails,
 			Violations: violations,
 		}
 	}


### PR DESCRIPTION
### ISSUE

[#12] - [Bug] Typo in Assessment report tool output

In the CLI Assessment tool report, there's a small typo.

```diff
  "errors": [
            {
-                "check": "GoCGaurdrails",
+                "check": "GoCGuardrails", 
```


---