### PR TITLE
feature(check): add rfc3339 timestamps

### DIFF
--- a/internal/pkg/types/checks.go
+++ b/internal/pkg/types/checks.go
@@ -1,6 +1,8 @@
 package types
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 type CheckResult uint16
 
@@ -43,10 +45,11 @@ const (
 )
 
 type CheckReport struct {
-	EntityType string                    `json:"entity_type"`
-	EntityId   string                    `json:"entity_id"`
-	Results    map[CheckType]CheckResult `json:"results"`
-	Errors     []CheckError              `json:"errors"`
+	EntityType 	string						`json:"entity_type"`
+	EntityId   	string						`json:"entity_id"`
+	Timestamp	string						`json:"rfc3339_timestamp"`
+	Results    	map[CheckType]CheckResult	`json:"results"`
+	Errors     	[]CheckError				`json:"errors"`
 }
 
 type ICheckable interface {

--- a/internal/pkg/types/github/organization.go
+++ b/internal/pkg/types/github/organization.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"gh_foundations/internal/pkg/types"
 	"slices"
+	"time"
 
 	"github.com/google/go-github/v61/github"
 )
@@ -16,14 +17,15 @@ type Organization struct {
 func (o *Organization) Check(checkTypes []types.CheckType) types.CheckReport {
 	report := types.CheckReport{
 		EntityType: "github_organization",
-		EntityId:   o.GetName(),
+		EntityId:   o.GetLogin(),
+		Timestamp:  time.Now().Format(time.RFC3339), // Syslog compliant timestamp
 		Results:    make(map[types.CheckType]types.CheckResult),
 		Errors:     []types.CheckError{},
 	}
 	for _, t := range checkTypes {
 		switch t {
 		case types.GoCGuardrails:
-			r, err := o.GoCGaurdrailsCompliant()
+			r, err := o.GoCGuardrailsCompliant()
 			if err != nil {
 				report.Errors = append(report.Errors, *err)
 			}
@@ -36,7 +38,7 @@ func (o *Organization) Check(checkTypes []types.CheckType) types.CheckReport {
 }
 
 // Custom repository roles for an organization need to be accessed separately from settings
-func (o *Organization) GoCGaurdrailsCompliant() (types.CheckResult, *types.CheckError) {
+func (o *Organization) GoCGuardrailsCompliant() (types.CheckResult, *types.CheckError) {
 	var allErrors error
 	violations := make(map[string]string)
 	checks := []func(org *Organization) (string, error){

--- a/internal/pkg/types/github/repository.go
+++ b/internal/pkg/types/github/repository.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"gh_foundations/internal/pkg/types"
 	"reflect"
+	"time"
 
 	"github.com/google/go-github/v61/github"
 )
@@ -19,13 +20,14 @@ func (r *Repository) Check(checkTypes []types.CheckType) types.CheckReport {
 	report := types.CheckReport{
 		EntityType: "github_repository",
 		EntityId:   r.slug,
+		Timestamp:	time.Now().Format(time.RFC3339), // Syslog compliant timestamp
 		Results:    make(map[types.CheckType]types.CheckResult),
 		Errors:     []types.CheckError{},
 	}
 	for _, t := range checkTypes {
 		switch t {
 		case types.GoCGuardrails:
-			r, err := r.GoCGaurdrailsCompliant()
+			r, err := r.GoCGuardrailsCompliant()
 			if err != nil {
 				report.Errors = append(report.Errors, *err)
 			}
@@ -37,7 +39,7 @@ func (r *Repository) Check(checkTypes []types.CheckType) types.CheckReport {
 	return report
 }
 
-func (r *Repository) GoCGaurdrailsCompliant() (types.CheckResult, *types.CheckError) {
+func (r *Repository) GoCGuardrailsCompliant() (types.CheckResult, *types.CheckError) {
 	var allErrors error
 	violations := make(map[string]string)
 	checks := []func(repo *Repository) (string, error) {


### PR DESCRIPTION
### ISSUE

[#17] - [Feature] Output Assessment tool results in Azure Sentinel compatible format

In order to import into Azure Sentinel, messages must be in either `Syslog` or `Common Event Format (CEF)` format. The details [can be found here](https://learn.microsoft.com/en-us/azure/sentinel/data-connectors-reference#syslog-and-common-event-format-cef-connectors).

The client has requested that:
* timestamp (RFC 3339 Format), and 
* Repository(/Org) name 

be included in each log message.

The Assessment tool should provide a way to output messages in the compliant format.

---

### ADDITIONALLY

The organization name was not being output (not set by the GH CLI). This has been resolved.


---