### PR TITLE
Team set hcl generation

### DIFF
--- a/cmd/gen/common/hcl.go
+++ b/cmd/gen/common/hcl.go
@@ -13,7 +13,7 @@ type HCLWritable interface {
 func OutputHCLToFile(fileName string, writable HCLWritable) error {
 	file := hclwrite.NewEmptyFile()
 	writable.WriteHCL(file)
-	output, err := os.Create("repository_set.inputs.hcl")
+	output, err := os.Create(fileName)
 	if err != nil {
 		return err
 	}

--- a/cmd/gen/common/model.go
+++ b/cmd/gen/common/model.go
@@ -157,7 +157,9 @@ func (m model[T]) View() string {
 func (m *model[T]) reset() {
 	for i := range m.questions {
 		m.questions[i].Reset()
+		m.questions[i].Blur()
 	}
 	m.currentQuestion = 0
+	m.questions[0].Focus()
 	m.submitted = false
 }

--- a/cmd/gen/common/model.go
+++ b/cmd/gen/common/model.go
@@ -86,6 +86,7 @@ func (m model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			q.SetDimensions(msg.Width, msg.Height)
 			resizeCmds = append(resizeCmds, q.Update(msg))
 		}
+		m.questions[0].Focus()
 		m.viewport.SetContent(m.questions[0].View())
 		return m, tea.Batch(resizeCmds...)
 	case tea.KeyMsg:

--- a/cmd/gen/gen.go
+++ b/cmd/gen/gen.go
@@ -2,6 +2,7 @@ package gen
 
 import (
 	repositoryset "gh_foundations/cmd/gen/repository_set"
+	teamset "gh_foundations/cmd/gen/team_set"
 
 	"github.com/spf13/cobra"
 )
@@ -14,4 +15,5 @@ var GenCmd = &cobra.Command{
 
 func init() {
 	GenCmd.AddCommand(repositoryset.GenRepositorySetCmd)
+	GenCmd.AddCommand(teamset.GenTeamSetCmd)
 }

--- a/cmd/gen/team_set/interactive.go
+++ b/cmd/gen/team_set/interactive.go
@@ -1,0 +1,72 @@
+package teamset
+
+import (
+	"fmt"
+	"gh_foundations/cmd/gen/common"
+	githubfoundations "gh_foundations/internal/pkg/types/github_foundations"
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	yaml "gopkg.in/yaml.v2"
+)
+
+var questions []common.IQuestion = []common.IQuestion{
+	common.NewTextQuestion(
+		"Enter the name of the team",
+		"",
+	),
+	common.NewTextQuestion(
+		"Enter the description for the team",
+		"",
+	),
+	common.NewSelectQuestion(
+		"Select the level of privacy for the team",
+		[]string{
+			"secret",
+			"closed",
+		},
+	),
+	common.NewListQuestion(
+		"Enter the team maintainers",
+	),
+	common.NewListQuestion(
+		"Enter the team members",
+	),
+	common.NewTextQuestion(
+		"Enter the id of the parent team if any",
+		"",
+	),
+}
+
+func submitFunc(answers []string, teamSet *githubfoundations.TeamSetInput) {
+	team := new(githubfoundations.TeamInput)
+	team.Name = answers[0]
+	team.Description = answers[1]
+	team.Privacy = answers[2]
+	maintainers := make([]string, 0)
+	err := yaml.Unmarshal([]byte(answers[3]), &maintainers)
+	if err != nil {
+		fmt.Println("Error converting maintainers input to array of strings:", err)
+		os.Exit(1)
+	}
+	team.Maintainers = maintainers
+
+	members := make([]string, 0)
+	err = yaml.Unmarshal([]byte(answers[4]), &members)
+	if err != nil {
+		fmt.Println("Error converting members input to array of strings:", err)
+		os.Exit(1)
+	}
+	team.Members = members
+
+	team.ParentId = answers[5]
+	teamSet.Teams = append(teamSet.Teams, team)
+}
+
+func runInteractive() (*githubfoundations.TeamSetInput, error) {
+	m := common.NewModel(questions, new(githubfoundations.TeamSetInput), submitFunc)
+	if _, err := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion()).Run(); err != nil {
+		return nil, err
+	}
+	return m.Result, nil
+}

--- a/cmd/gen/team_set/team_set.go
+++ b/cmd/gen/team_set/team_set.go
@@ -1,0 +1,34 @@
+package teamset
+
+import (
+	"fmt"
+	"os"
+
+	"gh_foundations/cmd/gen/common"
+	githubfoundations "gh_foundations/internal/pkg/types/github_foundations"
+
+	zone "github.com/lrstanley/bubblezone"
+	"github.com/spf13/cobra"
+)
+
+var GenTeamSetCmd = &cobra.Command{
+	Use:   "team_set",
+	Short: "Generates an hcl file that contains a team set input. Can only be run interactively.",
+	Long:  `Generates an hcl file that contains a team set input. Can only be run interactively.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		zone.NewGlobal()
+		var teamSet *githubfoundations.TeamSetInput
+		var err error
+
+		teamSet, err = runInteractive()
+		if err != nil {
+			fmt.Println("Error running interactive mode:", err)
+			os.Exit(1)
+		}
+
+		if err := common.OutputHCLToFile("team_set.inputs.hcl", teamSet); err != nil {
+			fmt.Println("Error writing hcl file:", err)
+			os.Exit(1)
+		}
+	},
+}

--- a/internal/pkg/types/github_foundations/common.go
+++ b/internal/pkg/types/github_foundations/common.go
@@ -1,6 +1,8 @@
 package githubfoundations
 
-import "github.com/zclconf/go-cty/cty"
+import (
+	"github.com/zclconf/go-cty/cty"
+)
 
 func toCtyValueSlice(values []string) cty.Value {
 	if len(values) == 0 {
@@ -8,8 +10,8 @@ func toCtyValueSlice(values []string) cty.Value {
 	}
 
 	ctyValues := make([]cty.Value, len(values))
-	for _, v := range values {
-		ctyValues = append(ctyValues, cty.StringVal(v))
+	for i, v := range values {
+		ctyValues[i] = cty.StringVal(v)
 	}
 	return cty.ListVal(ctyValues)
 }

--- a/internal/pkg/types/github_foundations/common.go
+++ b/internal/pkg/types/github_foundations/common.go
@@ -1,0 +1,15 @@
+package githubfoundations
+
+import "github.com/zclconf/go-cty/cty"
+
+func toCtyValueSlice(values []string) cty.Value {
+	if len(values) == 0 {
+		return cty.ListValEmpty(cty.String)
+	}
+
+	ctyValues := make([]cty.Value, len(values))
+	for _, v := range values {
+		ctyValues = append(ctyValues, cty.StringVal(v))
+	}
+	return cty.ListVal(ctyValues)
+}

--- a/internal/pkg/types/github_foundations/repository_set.go
+++ b/internal/pkg/types/github_foundations/repository_set.go
@@ -75,7 +75,7 @@ func (r *RepositoryInput) GetCtyValue() cty.Value {
 	mapVal["delete_head_on_merge"] = cty.BoolVal(r.DeleteHeadBranchOnMerge)
 	mapVal["requires_web_commit_signing"] = cty.BoolVal(r.RequiresWebCommitSignOff)
 	mapVal["dependabot_security_updates"] = cty.BoolVal(r.DependabotSecurityUpdates)
-	mapVal["protected_branches"] = cty.ListValEmpty(cty.String)
+	mapVal["protected_branches"] = toCtyValueSlice(r.ProtectedBranches)
 	mapVal["allow_auto_merge"] = cty.BoolVal(r.AllowAutoMerge)
 
 	// Optional fields

--- a/internal/pkg/types/github_foundations/repository_set.go
+++ b/internal/pkg/types/github_foundations/repository_set.go
@@ -70,15 +70,7 @@ func (r *RepositoryInput) GetCtyValue() cty.Value {
 	mapVal["default_branch"] = cty.StringVal(r.DefaultBranch)
 	mapVal["advance_security"] = cty.BoolVal(r.AdvanceSecurity)
 	mapVal["has_vulnerability_alerts"] = cty.BoolVal(r.HasVulnerabilityAlerts)
-	topics := []cty.Value{}
-	for _, topic := range r.Topics {
-		topics = append(topics, cty.StringVal(topic))
-	}
-	if len(topics) > 0 {
-		mapVal["topics"] = cty.ListVal(topics)
-	} else {
-		mapVal["topics"] = cty.ListValEmpty(cty.String)
-	}
+	mapVal["topics"] = toCtyValueSlice(r.Topics)
 	mapVal["homepage"] = cty.StringVal(r.Homepage)
 	mapVal["delete_head_on_merge"] = cty.BoolVal(r.DeleteHeadBranchOnMerge)
 	mapVal["requires_web_commit_signing"] = cty.BoolVal(r.RequiresWebCommitSignOff)
@@ -88,27 +80,17 @@ func (r *RepositoryInput) GetCtyValue() cty.Value {
 
 	// Optional fields
 	if len(r.OrganizationActionSecrets) > 0 {
-		orgActionSecrets := []cty.Value{}
-		for _, secret := range r.OrganizationActionSecrets {
-			orgActionSecrets = append(orgActionSecrets, cty.StringVal(secret))
-		}
-		mapVal["organization_action_secrets"] = cty.ListVal(orgActionSecrets)
+		mapVal["organization_action_secrets"] = toCtyValueSlice(r.OrganizationActionSecrets)
+	}
 
-	}
 	if len(r.OrganizationCodespaceSecrets) > 0 {
-		orgCodespaceSecrets := []cty.Value{}
-		for _, secret := range r.OrganizationCodespaceSecrets {
-			orgCodespaceSecrets = append(orgCodespaceSecrets, cty.StringVal(secret))
-		}
-		mapVal["organization_codespace_secrets"] = cty.ListVal(orgCodespaceSecrets)
+		mapVal["organization_codespace_secrets"] = toCtyValueSlice(r.OrganizationCodespaceSecrets)
 	}
+
 	if len(r.OrganizationDependabotSecrets) > 0 {
-		orgDependaBotSecrets := []cty.Value{}
-		for _, secret := range r.OrganizationDependabotSecrets {
-			orgDependaBotSecrets = append(orgDependaBotSecrets, cty.StringVal(secret))
-		}
-		mapVal["organization_dependabot_secrets"] = cty.ListVal(orgDependaBotSecrets)
+		mapVal["organization_dependabot_secrets"] = toCtyValueSlice(r.OrganizationDependabotSecrets)
 	}
+
 	if len(r.ActionSecrets) > 0 {
 		actionSecretsMap := make(map[string]cty.Value)
 		for key, val := range r.ActionSecrets {

--- a/internal/pkg/types/github_foundations/team_set.go
+++ b/internal/pkg/types/github_foundations/team_set.go
@@ -1,0 +1,45 @@
+package githubfoundations
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Module Root Inputs
+
+type TeamSetInput struct {
+	Teams []*TeamInput
+}
+
+func (r *TeamSetInput) WriteHCL(file *hclwrite.File) {
+	rootBody := file.Body()
+	rootBodyMap := make(map[string]cty.Value)
+
+	teams := make(map[string]cty.Value)
+	for _, team := range r.Teams {
+		teams[team.Name] = team.GetCtyValue()
+	}
+
+	rootBodyMap["teams"] = cty.ObjectVal(teams)
+	rootBody.SetAttributeValue("inputs", cty.ObjectVal(rootBodyMap))
+}
+
+type TeamInput struct {
+	Name        string
+	Description string
+	Privacy     string
+	Maintainers []string
+	Members     []string
+	ParentId    string
+}
+
+func (t *TeamInput) GetCtyValue() cty.Value {
+	mapVal := make(map[string]cty.Value)
+	mapVal["description"] = cty.StringVal(t.Description)
+	mapVal["privacy"] = cty.StringVal(t.Privacy)
+	mapVal["parent_id"] = cty.StringVal(t.ParentId)
+	mapVal["maintainers"] = toCtyValueSlice(t.Maintainers)
+	mapVal["members"] = toCtyValueSlice(t.Members)
+
+	return cty.ObjectVal(mapVal)
+}

--- a/internal/pkg/types/github_foundations/team_set.go
+++ b/internal/pkg/types/github_foundations/team_set.go
@@ -37,7 +37,11 @@ func (t *TeamInput) GetCtyValue() cty.Value {
 	mapVal := make(map[string]cty.Value)
 	mapVal["description"] = cty.StringVal(t.Description)
 	mapVal["privacy"] = cty.StringVal(t.Privacy)
-	mapVal["parent_id"] = cty.StringVal(t.ParentId)
+
+	if len(t.ParentId) > 0 {
+		mapVal["parent_id"] = cty.StringVal(t.ParentId)
+	}
+
 	mapVal["maintainers"] = toCtyValueSlice(t.Maintainers)
 	mapVal["members"] = toCtyValueSlice(t.Members)
 


### PR DESCRIPTION
Adds a sub command for generating teamsets. Only implements interactive mode.

Also fixes a few bugs:
- repository set protected branches weren't being created
- converting []string to cty.Value function didn't work
- file name input wasn't being used for output file
- first question wasn't being focused